### PR TITLE
Revert "Add the time the workflow status was set to the item table"

### DIFF
--- a/src/main/resources/db/migration/V6__imrt_ddl.sql
+++ b/src/main/resources/db/migration/V6__imrt_ddl.sql
@@ -1,8 +1,0 @@
-/******************************************************************************
-* Add the time the workflow status was set to the item table
-******************************************************************************/
-/* Use default for existing rows */
-ALTER TABLE item ADD COLUMN workflow_status_set_at TIMESTAMPTZ NOT NULL DEFAULT timestamp with time zone '1970-01-01';
-
-/* No new rows without a value */
-ALTER TABLE item ALTER COLUMN workflow_status_set_at DROP DEFAULT;


### PR DESCRIPTION
Reverts SmarterApp/AP_IMRT_Schema#10

* I merged this in before Ingest was ready.  Ingest would fail when-ever it tries to insert an item, it'll fail because we don't have a value to insert into this field.
* This schema change shouldn't have been merged into `develop` before Ingest was ready to deal with it.