### PR TITLE
Feature/time workflow

### DIFF
--- a/src/main/resources/db/migration/V6__imrt_ddl.sql
+++ b/src/main/resources/db/migration/V6__imrt_ddl.sql
@@ -1,6 +1,7 @@
 /******************************************************************************
 * Add the time the workflow status was set to the item table
 ******************************************************************************/
+
 /* Use default for existing rows */
 ALTER TABLE item ADD COLUMN workflow_status_set_at TIMESTAMPTZ NOT NULL DEFAULT timestamp with time zone '1970-01-01';
 


### PR DESCRIPTION
@swilson11 , @jeffjohnson9046 merged your schema changes a bit prematurely.  He reverted that merge and this PR is simply to reinstate your DB changes whenever the ingest service is updated to populate the workflow status change date.

