### PR TITLE
IMRT-424: Schema migration to prevent duplicate attachment records

### DIFF
--- a/src/main/resources/db/migration/V17__imrt_ddl.sql
+++ b/src/main/resources/db/migration/V17__imrt_ddl.sql
@@ -1,0 +1,50 @@
+CREATE TEMPORARY TABLE item_attachment_temp (
+    item_key integer NOT NULL,
+    file_name character varying NOT NULL,
+    file_type character varying NOT NULL,
+    uploaded_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_by character varying NOT NULL
+);
+
+-- Get the first item_attachment record that was created
+INSERT INTO item_attachment_temp (item_key, file_name, file_type, uploaded_at, created_at, updated_at, updated_by)
+SELECT
+	item_key,
+	file_name,
+	file_type,
+	uploaded_at,
+	MIN(updated_at),
+	MIN(created_at),
+	updated_by
+FROM
+	item_attachment
+GROUP BY
+	item_key,
+	file_name,
+	file_type,
+	uploaded_at,
+	updated_by;
+
+
+ALTER TABLE item_attachment DROP CONSTRAINT item_attachment_pkey;
+ALTER TABLE item_attachment DROP COLUMN key;
+
+DELETE FROM item_attachment;
+
+INSERT INTO item_attachment (item_key, file_name, file_type, uploaded_at, created_at, updated_at, updated_by)
+SELECT
+  item_key,
+  file_name,
+  file_type,
+  uploaded_at,
+  created_at,
+  updated_at,
+  updated_by
+FROM
+  item_attachment_temp;
+
+ALTER TABLE item_attachment ADD CONSTRAINT item_attachment_pkey PRIMARY KEY (item_key, file_name);
+
+DROP TABLE item_attachment_temp;

--- a/src/main/resources/db/migration/V18__imrt_ddl.sql
+++ b/src/main/resources/db/migration/V18__imrt_ddl.sql
@@ -14,7 +14,7 @@ INSERT INTO item_attachment_temp (item_key, file_name, file_type, uploaded_at, c
     item_key,
     file_name,
     file_type,
-    uploaded_at,
+    MIN(uploaded_at),
     MIN(updated_at),
     MIN(created_at),
     updated_by
@@ -24,9 +24,7 @@ INSERT INTO item_attachment_temp (item_key, file_name, file_type, uploaded_at, c
     item_key,
     file_name,
     file_type,
-    uploaded_at,
     updated_by;
-
 
 ALTER TABLE item_attachment DROP CONSTRAINT item_attachment_pkey;
 ALTER TABLE item_attachment DROP COLUMN key;


### PR DESCRIPTION
[IMRT-424](https://jira.fairwaytech.com/browse/IMRT-424):
* Drop auto-generated key
* SQL to eliminate duplicate records
* Create composite primary key on `item_key` and `file_name`
  * one item can have many attachments; an attachment cannot belong to more than one item