### PR TITLE
IAT-2024: add index to item table for searches

### DIFF
--- a/src/main/resources/db/migration/V29__imrt_ddl.sql
+++ b/src/main/resources/db/migration/V29__imrt_ddl.sql
@@ -1,0 +1,9 @@
+/*******************************************************************
+* Add index to item table to facilitate common searches
+********************************************************************/
+
+CREATE INDEX ix_item_id_associated_stimulus_id_workflow_status_grade_subject ON item(id,
+  associated_stimulus_id,
+  workflow_status,
+  grade,
+  subject);


### PR DESCRIPTION
[IAT-2024](https://jira.fairwaytech.com/browse/IAT-2024): Create an index on the `item` table that covers the most commonly-used fields in search requests.